### PR TITLE
Test travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ r:
   - devel
 sudo: required
 cache: packages
-dist: xenial
+os:
+  - linux
+  - osx
 
 services:
   - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
-language: R
+language: r
+r:
+  - oldrel
+  - release
+  - devel
 sudo: required
 cache: packages
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+# This runs old, current, and dev release of r on linux, but only current
+# release of r on osx. This decision was because the packages that travis tried
+# to download while testing out the osx build with dev version of r were not
+# available at the url. The erroring of this build had nothing to do with the 
+# SSMSE R package.
 
 language: r
-r:
-  - oldrel
-  - release
-  - devel
+jobs:
+  include:
+  - r: oldrel
+    os: linux
+  - r: release
+    os: linux
+  - r: devel
+    os: linux
+  - r: release
+    os: osx
 sudo: required
 cache: packages
-os:
-  - linux
-  - osx
 
 services:
   - xvfb


### PR DESCRIPTION
This adds 3 new builds to travis CI
- old and dev versions of R on linux
- current version of R on OSX

I tested out using old and dev versions of R on OSX but ran into some issues that had nothing to do with the SSMSE package. I think for now that testing the current version of R on OSX should be sufficient. I will go ahead and merge this in myself, as the changes are small and don't need a review.