### PR TITLE
Save EM results in different folders, add debugging when running from .par tool

### DIFF
--- a/R/develtools.R
+++ b/R/develtools.R
@@ -1,0 +1,57 @@
+# tools for SSMSE developer troubleshooting
+
+#' Change a model from running with par to running without par
+#' 
+#' The intention of this function is to help troubleshooting issues with the
+#' par file. It is intended mostly to help troubleshooting while developing 
+#' the SSMSE package, but may also be helpful with runtime testing.
+#' @param orig_mod_dir The original model directory
+#' @param new_mod_dir The new model directory (folder need not exist)
+test_no_par <- function(orig_mod_dir, new_mod_dir) {
+  message("Trying to run model in ", orig_mod_dir, " in a new directory", 
+          new_mod_dir, "and starting from values in the ctl file with no", 
+          " estimation to diagnose problem with the model.")
+  if(!dir.exists(new_mod_dir)){
+    dir.create(new_mod_dir)
+  }
+  copy_SS_inputs(orig_mod_dir, new_mod_dir, verbose = FALSE)
+  start <- r4ss::SS_readstarter(file.path(new_mod_dir, "starter.ss"),
+                                verbose = FALSE)
+  start$init_values_src <- 0 # read inits from ctl instead of par.
+  r4ss::SS_writestarter(start, dir = file.path(new_mod_dir), overwrite = TRUE, 
+                        verbose = FALSE)
+  try(run_ss_model(new_mod_dir, "-maxfn 0 -phase 50 -nohess", verbose = FALSE))
+  # read in the 2 par files.
+  orig_par <- readLines(file.path(orig_mod_dir, "ss.par"))
+  if(file.exists(file.path(new_mod_dir, "data.ss_new"))) {
+    new_par <- readLines(file.path(new_mod_dir, "ss.par"))
+    if(length(orig_par) != length(new_par)) {
+      new_par_names <- grep("^# [^N]", new_par, value = TRUE)
+      orig_par_names <- grep("^# [^N]", orig_par, value = TRUE)
+      missing_vars <- setdiff(new_par_names, orig_par_names)
+      if(length(orig_par) < length(new_par)) {
+        msg <-  " is missing the "
+      }
+      if(length(orig_par) > length(new_par)) {
+        msg <- " has added "
+      }
+      stop("Problem with the ss.par file - different number of lines. ",
+           "The original par file in ", orig_mod_dir, msg, " parameters: ",
+           paste0(missing_vars, collapse = ", " ))
+    } else {
+      stop("Problem with the ss.par file - same number of lines.",
+           "The original par file in ", orig_mod_dir, 
+           " has the same number of values as the new ",
+           "par in ", new_mod_dir, ", so not sure what the issue is.")
+    }
+    #TODO: develop some more sophisticated ways to look at par file diffs.
+  } else {
+    # problem is not with the par file, but with some other model misspecification.
+    stop("Problem with model - not ss.par related.",
+         "Model originally in ", orig_mod_dir, "could not be run from values", 
+         "in the ctl file, suggesting the issue is not with bad par file ",
+         " specification. Please look at ", 
+         file.path(orig_mod_dir, "echoinput.sso"), " to see what went wrong.")
+  }
+  invisible(orig_mod_dir)
+}

--- a/R/extendOM.R
+++ b/R/extendOM.R
@@ -94,7 +94,8 @@ extend_OM <- function(catch,
                          overwrite = TRUE, verbose = FALSE)
   #Run SS with the new catch set as forecast targets. This will use SS to 
   #calculate the F required in the OM to achieve these catches.
-  run_ss_model(OM_dir, "-maxfn 0 -phase 50 -nohess", verbose = verbose)
+  run_ss_model(OM_dir, "-maxfn 0 -phase 50 -nohess", verbose = verbose,
+               debug_par_run = TRUE)
   #Load the SS results 
   outlist <- r4ss::SS_output(OM_dir, verbose = FALSE, printstats = FALSE, 
                              covar = FALSE,warn = FALSE, readwt = FALSE)

--- a/R/initOM.R
+++ b/R/initOM.R
@@ -43,7 +43,8 @@ create_OM <- function(OM_out_dir,
   r4ss::SS_writestarter(start, dir = OM_out_dir, verbose = FALSE,
                         overwrite = TRUE, warn = FALSE)
   # run model to get standardized output ----
-  run_ss_model(OM_out_dir, "-maxfn 0 -phase 50 -nohess", verbose = verbose)
+  run_ss_model(OM_out_dir, "-maxfn 0 -phase 50 -nohess", debug_par_run = TRUE, 
+               verbose = verbose)
   # read in files to use ----
   dat <- r4ss::SS_readdat(file = file.path(OM_out_dir, start$datfile), 
                           verbose = FALSE, section = 1)
@@ -292,7 +293,8 @@ create_OM <- function(OM_out_dir,
     if(file.exists(file.path(OM_out_dir, "control.ss_new"))) {
       file.remove(file.path(OM_out_dir, "control.ss_new"))
     }
-    run_ss_model(OM_out_dir, "-maxfn 0 -phase 50 -nohess", verbose = verbose)
+    run_ss_model(OM_out_dir, "-maxfn 0 -phase 50 -nohess", verbose = verbose, 
+                 debug_par_run = TRUE)
     if(!file.exists(file.path(OM_out_dir, "control.ss_new"))){
       stop("The OM model created is not valid; it did not run and produce a\n",
            "control.ss_new file. Please try running the OM model created\n", 
@@ -344,13 +346,18 @@ create_OM <- function(OM_out_dir,
 #'   SS_readdat is equivalent to specifying nboot = 1.
 #' @param init_run Is this the initial iteration of the OM? Defaults to FALSE.
 #' @template verbose
+#' @param debug_par_run If set to TRUE, and the run fails, a new folder called
+#'  error_check will be created, and the model will be run from control start 
+#'  values instead of ss.par. The 2 par files are then compared to help debug
+#'  the issue with the model run. Defaults to TRUE.
 #' @author Kathryn Doering
 #' @importFrom r4ss SS_readdat SS_readstarter SS_writestarter
 run_OM <- function(OM_dir, 
                         boot = TRUE,
                         nboot = 1, 
                         init_run = FALSE, 
-                        verbose = FALSE) {
+                        verbose = FALSE, 
+                        debug_par_run = TRUE) {
   # make sure OM generates the correct number of data sets.
   if (boot) {
     max_section <- nboot + 2
@@ -365,7 +372,8 @@ run_OM <- function(OM_dir,
                         warn = FALSE)
   }
   # run SS and get the data set
-  run_ss_model(OM_dir, "-maxfn 0 -phase 50 -nohess", verbose = verbose)
+  run_ss_model(OM_dir, "-maxfn 0 -phase 50 -nohess", verbose = verbose,
+               debug_par_run = debug_par_run)
 
   dat <- r4ss::SS_readdat(file.path(OM_dir,"data.ss_new"), 
                           section = max_section, 

--- a/R/parse_MS.R
+++ b/R/parse_MS.R
@@ -339,7 +339,8 @@ get_no_EM_catch_df <- function(OM_dir, yrs, MS = "last_yr_catch") {
   writeLines(par, file.path(OM_dir, "ss.par"))
   #Run SS with the new catch set as forecast targets. This will use SS to 
   #calculate the F required in the OM to achieve these catches.
-  run_ss_model(OM_dir, "-maxfn 0 -phase 50 -nohess", verbose = FALSE)
+  run_ss_model(OM_dir, "-maxfn 0 -phase 50 -nohess", verbose = FALSE, 
+               debug_par_run = TRUE)
   #Load the SS results 
   outlist <- r4ss::SS_output(OM_dir, verbose = FALSE, printstats = FALSE, 
                              covar = FALSE, warn = FALSE, readwt = FALSE)

--- a/R/runSS.R
+++ b/R/runSS.R
@@ -33,6 +33,10 @@
 #' @param check_run Should it be checked that the model ran by deleting the 
 #'  data.ss_new file if one exists and then checking if one was created?
 #'  Defaults to TRUE.
+#' @param debug_par_run If set to TRUE, and the run fails, a new folder called
+#'  error_check will be created, and the model will be run from control start 
+#'  values instead of ss.par. The 2 par files are then compared to help debug
+#'  the issue with the model run. Defaults to FALSE.
 #' @template verbose 
 #' @param ... Anything else to pass to \code{\link[base]{system}}.
 #' @author Sean C. Anderson, Kathryn Doering
@@ -43,6 +47,7 @@ run_ss_model <- function(dir,
                          admb_pause = 0.05, 
                          show.output.on.console = FALSE,
                          check_run = TRUE,
+                         debug_par_run = FALSE,
                          verbose = FALSE,
                          ...) {
   #TODO: create Input checking: check form of admb options
@@ -70,12 +75,18 @@ run_ss_model <- function(dir,
            invisible = TRUE, ignore.stdout = ignore.stdout,
            show.output.on.console = show.output.on.console, ...)
   }
-  if(check_run == TRUE){ 
+  if(check_run == TRUE) { 
     if(!file.exists(ss_new_path)) {
-      stop("data.ss_new was not created during the model run, which suggests ",
-           "SS did not run correctly")
+      if(debug_par_run) {
+        test_no_par(orig_mod_dir = dir, 
+                    new_mod_dir = file.path(dirname(dir), "OM_error_check"))
+        #note that this will exit on error.
+      } else {
+        stop("data.ss_new was not created during the model run, which suggests ",
+             "SS did not run correctly")
+      }
     } else {
-      if (verbose) "data.ss_new created druing model run."
+      if (verbose) "data.ss_new created during model run."
     }
   }
   Sys.sleep(admb_pause)

--- a/R/runSSMSE.R
+++ b/R/runSSMSE.R
@@ -586,8 +586,9 @@ run_SSMSE_iter <- function(out_dir     = NULL,
   # get and create directories, copy model files ----
   # assign or reassign OM_dir and OM_in_dir in case they weren't specified
   # as inputs
-  out_loc <- create_out_dirs(out_dir, niter, OM_name, OM_in_dir, MS,
-                                EM_name, EM_in_dir)
+  out_loc <- create_out_dirs(out_dir = out_dir, niter = niter, OM_name = OM_name,
+                             OM_in_dir = OM_in_dir, MS = MS,
+                                EM_name = EM_name, EM_in_dir = EM_in_dir)
   if(is.null(out_loc)) { #out loc returns false if the iteration was already run.
     return(FALSE)
   }
@@ -595,8 +596,11 @@ run_SSMSE_iter <- function(out_dir     = NULL,
   OM_in_dir <- out_loc[["OM_in_dir"]]
   EM_in_dir <- out_loc[["EM_in_dir"]]
   EM_out_dir <- out_loc[["EM_out_dir"]]
-  copy_model_files(OM_in_dir, OM_out_dir, MS, EM_in_dir, EM_out_dir)
-  
+  if(!is.null(EM_out_dir)) {
+    EM_out_dir_basename <- strsplit(EM_out_dir, "_init$")[[1]][1]
+  }
+  copy_model_files(OM_in_dir = OM_in_dir, OM_out_dir = OM_out_dir, 
+                   EM_in_dir = EM_in_dir, EM_out_dir= EM_out_dir)
   # clean model files ----
   # want to do this as soon as possible to "fail fast"
   # for now, this just gets rid of -year value observations, but could do
@@ -679,6 +683,15 @@ run_SSMSE_iter <- function(out_dir     = NULL,
     }
     message("Finished running and sampling OM through year ", new_OM_dat$endyr, 
             ".")
+
+    # if using an EM, want to save results to a new folder
+    if(!is.null(EM_out_dir)) {
+      new_EM_out_dir <- paste0(EM_out_dir_basename,"_", yr)
+      dir.create(new_EM_out_dir)
+      success <- copy_model_files(EM_in_dir = EM_out_dir, 
+                                  EM_out_dir = new_EM_out_dir)
+      EM_out_dir <- new_EM_out_dir
+    }
     # Only want data for the new years: (yr+nyrs_assess):yr
     # create the new dataset to input into the EM
     # loop EM and get management quantities.

--- a/tests/testthat/test-runSSMSE.R
+++ b/tests/testthat/test-runSSMSE.R
@@ -34,7 +34,7 @@ test_that("run_SSMSE_iter runs with an EM", {
   expect_true(file.exists(file.path(temp_path, "1", "cod_OM", "data.ss_new")))
   expect_true(result)
   # some more specific values, specific to the scenario above.
-  dat <- SS_readdat(file.path(temp_path, "1", "cod_EM", "data.ss_new"), verbose = FALSE)
+  dat <- SS_readdat(file.path(temp_path, "1", "cod_EM_106", "data.ss_new"), verbose = FALSE)
   added_catch <- dat$catch[dat$catch$year %in% catch_add_yrs, ]
   old_catch <- dat$catch[dat$catch$year < min(catch_add_yrs), ]
   expect_true(all(added_catch$catch_se == 0.005))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -283,7 +283,7 @@ unlink(file.path(out_dir, "5"), recursive = TRUE)
                                    MS = "EM",
                                    EM_name = "cod",
                                    EM_in_dir = NULL)
-  created_dir_name_1 <- file.path(out_dir, "5", "cod_EM")
+  created_dir_name_1 <- file.path(out_dir, "5", "cod_EM_init")
   expect_true(dir.exists(created_dir_name_1))
   expect_true(created_mod_1[["EM_out_dir"]] == created_dir_name_1)
   expect_true(created_mod_1[["EM_in_dir"]] ==
@@ -297,11 +297,10 @@ unlink(file.path(out_dir, "5"), recursive = TRUE)
                                    MS = "EM", 
                                    EM_name = "custom_cod", 
                                    EM_in_dir = cod_EM_in_dir)
-  created_dir_name_2 <- file.path(out_dir, "6", "custom_cod_EM")
+  created_dir_name_2 <- file.path(out_dir, "6", "custom_cod_EM_init")
   expect_true(dir.exists(created_dir_name_2))
   expect_true(created_mod_2[["EM_out_dir"]] == created_dir_name_2)
-  expect_true(created_mod_2[["EM_in_dir"]] == 
-                cod_EM_in_dir)
+  expect_true(created_mod_2[["EM_in_dir"]] == cod_EM_in_dir)
   # EM not named, mock as custom
   cod_EM_in_dir <- system.file("extdata", "models", "cod", package = "SSMSE")
   created_mod_3 <- create_out_dirs(out_dir = out_dir, 
@@ -311,7 +310,7 @@ unlink(file.path(out_dir, "5"), recursive = TRUE)
                                    MS = "EM", 
                                    EM_name = NULL, 
                                    EM_in_dir = cod_EM_in_dir)
-  created_dir_name_3 <- file.path(out_dir, "7", "cod_EM")
+  created_dir_name_3 <- file.path(out_dir, "7", "cod_EM_init")
   expect_true(dir.exists(created_dir_name_3))
   expect_true(created_mod_3[["EM_out_dir"]] == created_dir_name_3)
   expect_true(created_mod_3[["EM_in_dir"]] == cod_EM_in_dir)
@@ -339,18 +338,25 @@ unlink(file.path(out_dir, "5"), recursive = TRUE)
    
    success <- copy_model_files(OM_in_dir = cod_in_dir, OM_out_dir = OM_out_dir)
    expect_equivalent(success, c(TRUE, TRUE))
+
    #expect_error b/c model files still exist
    expect_error(copy_model_files(OM_in_dir = cod_in_dir, OM_out_dir = OM_out_dir), 
                 "Problem copying SS OM .ss_new files", fixed = TRUE)
    unlink(OM_out_dir, recursive = TRUE)
    dir.create(OM_out_dir)
    success <- copy_model_files(OM_in_dir = cod_in_dir, OM_out_dir = OM_out_dir,
-                    MS = "EM", EM_in_dir = cod_in_dir, EM_out_dir = EM_out_dir)
+                    EM_in_dir = cod_in_dir, EM_out_dir = EM_out_dir)
+   expect_equivalent(success, c(TRUE, TRUE))
+   # copy over only the EM files to a new folder.
+   new_EM_folder <- file.path(new_out_dir, "EM_2000")
+   dir.create(new_EM_folder)
+   success_2 <- copy_model_files(EM_in_dir = EM_out_dir, 
+                                 EM_out_dir = new_EM_folder)
    expect_equivalent(success, c(TRUE, TRUE))
    unlink(OM_out_dir, recursive = TRUE)
    dir.create(OM_out_dir)
    expect_error(copy_model_files(OM_in_dir = cod_in_dir, OM_out_dir = OM_out_dir,
-                    MS = "EM", EM_in_dir = cod_in_dir, EM_out_dir = EM_out_dir), 
+                    EM_in_dir = cod_in_dir, EM_out_dir = EM_out_dir), 
                 "Problem copying SS EM files", fixed = TRUE)
  })
  

--- a/tests/testthat/test_develtools.R
+++ b/tests/testthat/test_develtools.R
@@ -1,0 +1,48 @@
+context("Test functions in develtools.R")
+
+# create a temporary location to avoid adding files to the repo.
+temp_path <- file.path(tempdir(), "test-develtools")
+dir.create(temp_path, showWarnings = FALSE)
+wd <- getwd()
+on.exit(unlink(temp_path, recursive = TRUE), add = TRUE)
+
+extdat_path <- system.file("extdata", package = "SSMSE")
+file.copy(file.path(extdat_path, "models", "cod"), 
+          temp_path, recursive = TRUE)
+orig_mod_dir <- file.path(temp_path, "cod")
+# make sure originally is runing from par.
+start_orig <- r4ss::SS_readstarter(file.path(orig_mod_dir, "starter.ss"),
+                                   verbose = FALSE)
+start_orig$init_values_src <- 1 # read inits from ctl instead of par.
+r4ss::SS_writestarter(start_orig, dir = file.path(orig_mod_dir), overwrite = TRUE, 
+                      verbose = FALSE)
+
+# mock a bad par file by deleting a line
+orig_par <- readLines(file.path(orig_mod_dir, "ss.par"))
+writeLines(orig_par, file.path(temp_path, "good_ss.par"))
+fcast_imp_line <- grep("^# Fcast_impl_error:$", orig_par)
+bad_par <- orig_par[-c(fcast_imp_line, fcast_imp_line+1)]
+writeLines(bad_par, file.path(orig_mod_dir, "ss.par"))
+new_mod_dir <- file.path(temp_path, "new_mod_dir")
+
+test_that("test_no_par works as expected", {
+  skip_on_cran()
+  expect_error(run_ss_model(orig_mod_dir, "-maxfn 0 -phase 50 -nohess", 
+                            verbose = FALSE),
+               "data.ss_new was not created during the model run", 
+               fixed = TRUE)
+  expect_error(test_no_par(orig_mod_dir = orig_mod_dir,
+              new_mod_dir = new_mod_dir), 
+              "Problem with the ss.par file - different number of lines.")
+  unlink(new_mod_dir, recursive = TRUE)
+  # manipulate the fcast file to make some other issue
+  fore <- r4ss::SS_readforecast(file.path(orig_mod_dir, "forecast.ss"), 
+                                verbose = FALSE)
+  fore$benchmarks <- 3
+  r4ss::SS_writeforecast(fore, dir = orig_mod_dir,
+                         verbose = FALSE, overwrite = TRUE)
+  expect_error(test_no_par(orig_mod_dir = orig_mod_dir,
+                           new_mod_dir = new_mod_dir), 
+               "Problem with model - not ss.par related", 
+               fixed = TRUE)
+})


### PR DESCRIPTION
- EM results are now saved in different folders instead of overwriting the same folder each time
- Now for runs of the OM which always use .par, if the run isn't successful, the function `test_no_par` will copy over the model files and try running it from the control file instead. Then, par files from the runs are compared to determine if any lines are missing/added to the par file or if there is some other problem. This should help the developers debug code, but may also be useful for runtime testing.