### PR TITLE
Uses same workflow but from ss3sim

### DIFF
--- a/.github/workflows/call-update-ss3-version.yml
+++ b/.github/workflows/call-update-ss3-version.yml
@@ -6,4 +6,4 @@ on:
 name: call-update-ss3
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/update-ss3-version.yml@main
+    uses: ss3sim/ss3sim/.github/workflows/update-ss3-version.yml@main


### PR DESCRIPTION
ss3sim/ss3sim/.github/workflows/update-ss3-version.yml@main instead of from the nmfs-stock-synthesis organization.