### PR TITLE
use cran mirror for assertive packages, check fixes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^man/figures/README*
 ^inst/bookdown$
 ^JOSS$
+^\.devcontainer/*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,10 @@ Suggests:
     testthat
 Remotes:
     r4ss/r4ss@main,
-    ss3sim/ss3sim@main
+    ss3sim/ss3sim@main,
+    cran/assertive.base@master,
+    cran/assertive.properties@master,
+    cran/assertive.types@master
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,7 @@
 .onAttach <- function(libname, pkgname) {
   packageStartupMessage(
     "Welcome to SSMSE version ",
-    packageVersion(pkgname),
+    utils::packageVersion(pkgname),
     " using Stock Synthesis 3.30.18."
   )
 }

--- a/man/create_scen_list.Rd
+++ b/man/create_scen_list.Rd
@@ -95,7 +95,7 @@ MA_years= the number of years to average index observations of when calculating 
 assess_freq=the number of years between full assessments during with an interim assessment will happen
 every year, and Index_weights is a vector of length n indexes that weights all indexes for multi index
 inference.
-interim_struct_list<-list(Beta=1,MA_years=3,assess_freq=5,Index_weights=rep(1,max(ref_index\link{,3})))}
+\code{interim_struct_list<-list(Beta=1,MA_years=3,assess_freq=5,Index_weights=rep(1,max(ref_index[,3])))}}
 }
 \description{
 Function to create parameter \code{scen_list} in

--- a/man/roxygen/templates/run_SSMSE_scen_list.R
+++ b/man/roxygen/templates/run_SSMSE_scen_list.R
@@ -54,7 +54,7 @@
 #'  assess_freq=the number of years between full assessments during with an interim assessment will happen
 #'  every year, and Index_weights is a vector of length n indexes that weights all indexes for multi index
 #'  inference.
-#'  interim_struct_list<-list(Beta=1,MA_years=3,assess_freq=5,Index_weights=rep(1,max(ref_index[,3])))
+#'  `interim_struct_list<-list(Beta=1,MA_years=3,assess_freq=5,Index_weights=rep(1,max(ref_index[,3])))`
 #' @param sample_catch_vec Should catch be sampled or fixed at the OM values? 
 #'   This can be a single Boolean (TRUE or FALSE) to apply to all scenarios or 
 #'   a vector of the same length as the number of scenarios. Defaults to FALSE.

--- a/man/run_SSMSE.Rd
+++ b/man/run_SSMSE.Rd
@@ -122,7 +122,7 @@ MA_years= the number of years to average index observations of when calculating 
 assess_freq=the number of years between full assessments during with an interim assessment will happen
 every year, and Index_weights is a vector of length n indexes that weights all indexes for multi index
 inference.
-interim_struct_list<-list(Beta=1,MA_years=3,assess_freq=5,Index_weights=rep(1,max(ref_index\link{,3})))}
+\code{interim_struct_list<-list(Beta=1,MA_years=3,assess_freq=5,Index_weights=rep(1,max(ref_index[,3])))}}
 
 \item{verbose}{Want verbose output? Defaults to FALSE.}
 


### PR DESCRIPTION
- Use cran mirror instead of cran for assertive packages, because the assertive packages were removed from CRAN.
- Fix some issues identified from R cmd check.