### PR TITLE
Bug catcher

### DIFF
--- a/R/MS_functions.R
+++ b/R/MS_functions.R
@@ -499,7 +499,8 @@ get_no_EM_catch_df <- function(OM_dir, yrs, MS = "last_yr_catch") {
     )
     # get F.
     F_vals <- get_F(outlist[["timeseries"]],
-      fleetnames = dat[["fleetinfo"]][dat[["fleetinfo"]][["type"]] %in% c(1, 2), "fleetname"]
+      fleetnames = dat[["fleetinfo"]][dat[["fleetinfo"]][["type"]] %in% c(1, 2), "fleetname"],
+      fleetnames_all = dat[["fleetinfo"]][["fleetname"]] # added to account for fleets of type==3
     )
     catch_F <- F_vals[["F_rate_fcast"]][
       ,

--- a/R/calc_F.R
+++ b/R/calc_F.R
@@ -12,7 +12,7 @@
 #'  a named vector of initial F values by Season and Fleet, ordered (and named)
 #'  as SS expects; and F_rate_fcast, a dataframe of forecasted F by Yr, Seas,
 #'  and fleet, ordered as SS would expect in F_rate.
-get_F <- function(timeseries, fleetnames) {
+get_F <- function(timeseries, fleetnames, fleetnames_all) {
   assertive.types::assert_is_data.frame(timeseries)
   # find the F columns
   F_col_ind <- grep("^F:_\\d+$", colnames(timeseries))
@@ -74,10 +74,11 @@ get_F <- function(timeseries, fleetnames) {
     # feed back as a named vector sorted by fleet, then season. Names are the
     # same as in the PARAMETERS section of report.sso
     init_F <- init_F[order(init_F[, "Fleet"], init_F[, "Seas"]), ]
-    fleetnames_df <- data.frame(
-      Fleet = seq_along(fleetnames),
-      fleetname = fleetnames
-    )
+    
+    # edit to account for fleets of type==3 in list of fleets
+    fleetnumbers = which(fleetnames_all %in% fleetnames)            
+    fleetnames_df<- data.frame(Fleet=fleetnumbers, fleetname=fleetnames)    
+    
     init_F <- merge(init_F, fleetnames_df)
     init_F_names <- paste0(
       "InitF_seas_", init_F[["Seas"]], "_flt_", init_F[["Fleet"]],

--- a/R/extendOM.R
+++ b/R/extendOM.R
@@ -379,7 +379,8 @@ update_OM <- function(OM_dir,
       # Extract the achieved F and Catch
       F_list <- get_F(
         timeseries = outlist[["timeseries"]],
-        fleetnames = dat[["fleetinfo"]][dat[["fleetinfo"]][["type"]] %in% c(1, 2), "fleetname"]
+        fleetnames = dat[["fleetinfo"]][dat[["fleetinfo"]][["type"]] %in% c(1, 2), "fleetname"],
+        fleetnames_all = dat[["fleetinfo"]][["fleetname"]] # added to account for fleets of type==3
       )
 
       units_of_catch <- dat[["fleetinfo"]][dat[["fleetinfo"]][["type"]] %in% c(1, 2), "units"]

--- a/R/initOM.R
+++ b/R/initOM.R
@@ -199,8 +199,9 @@ create_OM <- function(OM_out_dir,
   # use report.sso time series table to find the F's to put into the parlist.
   F_list <- get_F(
     timeseries = outlist[["timeseries"]],
-    fleetnames = dat[["fleetinfo"]][dat[["fleetinfo"]][["type"]] %in% c(1, 2), "fleetname"]
-  )
+    fleetnames = dat[["fleetinfo"]][dat[["fleetinfo"]][["type"]] %in% c(1, 2), "fleetname"],
+    fleetnames_all = dat[["fleetinfo"]][["fleetname"]] # add to account for fleets type=3
+  ) 
 
   # SINGLE_RUN_MODS:
   update_F_years <- (dat[["endyr"]] + 1):(dat[["endyr"]] + nyrs)

--- a/R/initOM_create_devs_list.R
+++ b/R/initOM_create_devs_list.R
@@ -152,10 +152,10 @@ match_parname <- function(list_pars, parlist) {
       obj = "S_parms"
     )
   )
-  par_name_tbl <- rbind(
-    par_name_tbl,
-    data.frame(pars = "rec_devs", obj = "recdev1")
-  )
+  ## Edit to allow for recdevs labeled recdev2 not recdev1
+  rdnme<-names(parlist)[grepl("recdev", names(parlist))][1]               
+  par_name_tbl <- rbind(par_name_tbl, data.frame(pars = "rec_devs",       
+                                                 obj = rdnme))      
   par_name_tbl <- rbind(par_name_tbl, data.frame(pars = "impl_error", obj = NA))
   if (isTRUE(list_pars == "all")) {
     # TODO: consider which parameters should be included in the "all" option.
@@ -444,7 +444,11 @@ calc_par_trend <- function(val_info,
   if (isTRUE(!is.na(val_info[val_info[["ts_param"]] == val_line, "first_yr_averaging"]) &
     !is.na(val_info[val_info[["ts_param"]] == val_line, "last_yr_averaging"]))) {
     if (parname == "rec_devs") {
-      tmp_vals <- data.frame(yrs = parlist[["recdev1"]][, 1], rec_devs = parlist[["recdev1"]][, 2])
+      
+      # EDITED bc par file labeled "recdev2" NOT "recdev1"
+      rdnme<-names(parlist)[grepl("recdev", names(parlist))][1]            
+      tmp_vals <- data.frame(yrs = parlist[[rdnme]][, 1],                  
+                             rec_devs = parlist[[rdnme]][, 2])              
       tmp_vals_2 <- data.frame(yrs = vals_df[["yrs"]], rec_devs = vals_df[["rec_devs"]])
       tmp_vals <- rbind(tmp_vals, tmp_vals_2)
       to_include <- which(tmp_vals[["yrs"]] >= val_info[val_info[["ts_param"]] == val_line, "first_yr_averaging"] &

--- a/tests/testthat/test-calc_F.R
+++ b/tests/testthat/test-calc_F.R
@@ -36,7 +36,7 @@ test_timeseries <- data.frame(
 test_fleetnames <- c("Fishery", "Survey")
 
 test_that("get_F works with multi yrs, fleets, and seasons", {
-  F_list <- get_F(timeseries = test_timeseries, fleetnames = test_fleetnames)
+  F_list <- get_F(timeseries = test_timeseries, fleetnames = test_fleetnames, fleetnames_all=test_fleetnames)
 
   expect_true(NROW(F_list[["F_df"]]) == nfleets * NROW(test_timeseries))
   expect_true(length(F_list) == 4) # b/c 4 components of output
@@ -66,7 +66,7 @@ test_that("get_F works with multi yrs, fleets, and seasons", {
 test_that("get_F works with multi yrs, fleets, and seasons but no init F", {
   no_init_F_timeseries <- test_timeseries
   no_init_F_timeseries[no_init_F_timeseries[["Era"]] == "INIT", c("F:_1", "F:_2")] <- 0
-  F_list <- get_F(timeseries = no_init_F_timeseries, fleetnames = test_fleetnames)
+  F_list <- get_F(timeseries = no_init_F_timeseries, fleetnames = test_fleetnames, fleetnames_all = test_fleetnames)
   expect_true(NROW(F_list[["F_df"]]) == nfleets * NROW(no_init_F_timeseries))
   expect_true(length(F_list) == 4) # b/c 4 components of output
   expect_equal(
@@ -88,7 +88,7 @@ test_that("get_F works with multi yrs, fleets, and seasons but no init F", {
 test_that("get_F works with multi yrs, fleets, and seasons but no F_rate_fcast", {
   no_fcast_F_timeseries <- test_timeseries
   no_fcast_F_timeseries[no_fcast_F_timeseries[["Era"]] == "FORE", c("F:_1", "F:_2")] <- 0
-  F_list <- get_F(timeseries = no_fcast_F_timeseries, fleetnames = test_fleetnames)
+  F_list <- get_F(timeseries = no_fcast_F_timeseries, fleetnames = test_fleetnames, fleetnames_all = test_fleetnames)
   expect_true(NROW(F_list[["F_df"]]) == nfleets * NROW(no_fcast_F_timeseries))
   expect_true(length(F_list) == 4) # b/c 4 components of output
   expect_equal(
@@ -113,11 +113,11 @@ test_that("get_F works with multi yrs, fleets, and seasons but no F_rate_fcast",
 
 test_that("get_F can catch bad input", {
   fleetnames_wrong_len <- c(test_fleetnames, "extra_fleetname")
-  expect_error(get_F(test_timeseries, fleetnames_wrong_len),
+  expect_error(get_F(test_timeseries, fleetnames_wrong_len, fleetnames_wrong_len),
     "is_of_length : fleetnames has length 3, not 2.",
     fixed = TRUE
   )
-  expect_error(get_F(as.matrix(test_timeseries), test_fleetnames),
+  expect_error(get_F(as.matrix(test_timeseries), test_fleetname, test_fleetnames),
     "is_data.frame : timeseries is not of class 'data.frame'",
     fixed = TRUE
   )


### PR DESCRIPTION
Hey Kathryn and Nathan!

Finally pull requesting. Three main changes herein: 

1. allowing for recdevs that are labeled other than recdev1 in the par file (e.g., recdev2); edited in calc_par_trend() and match_parname() functions
2. edited get_F() to correct a mistake in fleet labeling when there are fleets of type==3. Updated the function to include a fleetnames_all input, which contains all fleetnames (including those of type=3). I had to also change the test script to allow for an additional fleetnames_all input to the get_F() test functions. In the test script, I just set fleetnames_all = fleetnames. 
3. edit to run_SSMSE_iter() to adjust naming conventions from sample_struct to their standard column names (Yr, Seas, FltSvy, SE, etc). I originally thought this was simply an issue of the newer version of SS3, but I believe I also ran into trouble when running the cod example line-by-line. Not sure if it is related to the line-by-line method or what?

Thanks!