### PR TITLE
Fix  mean body size reading issue

### DIFF
--- a/R/checkinput.R
+++ b/R/checkinput.R
@@ -202,7 +202,7 @@ check_sample_struct <- function(sample_struct,
                                   ),
                                   meanbodywt = c(
                                     "Yr", "Seas", "FltSvy", "Part",
-                                    "Type", "SE"
+                                    "Type", "Std_in"
                                   ),
                                   MeanSize_at_Age_obs = c(
                                     "Yr", "Seas",

--- a/R/initOM.R
+++ b/R/initOM.R
@@ -473,8 +473,7 @@ run_OM <- function(OM_dir,
   start[["N_bootstraps"]] <- max_section
   start[["seed"]] <- seed
   r4ss::SS_writestarter(start,
-    dir = OM_dir, verbose = FALSE, overwrite = TRUE,
-    warn = FALSE
+    dir = OM_dir, verbose = FALSE, overwrite = TRUE
   )
 
   # run SS and get the data set

--- a/R/manipulate_EM.R
+++ b/R/manipulate_EM.R
@@ -152,8 +152,7 @@ run_EM <- function(EM_dir,
     start <- SS_readstarter(file.path(EM_dir, "starter.ss"), verbose = FALSE)
     start[["init_values_src"]] <- 1
     SS_writestarter(start,
-      dir = EM_dir, overwrite = TRUE, verbose = FALSE,
-      warn = FALSE
+      dir = EM_dir, overwrite = TRUE, verbose = FALSE
     )
   }
   if (hess == TRUE) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -283,8 +283,7 @@ clean_init_mod_files <- function(OM_out_dir, EM_out_dir = NULL, MS = "EM",
       r4ss::SS_writestarter(EM_start,
         dir = EM_out_dir,
         overwrite = TRUE,
-        verbose = FALSE,
-        warn = FALSE
+        verbose = FALSE
       )
     }
   }


### PR DESCRIPTION
See #171.

Also removes the `warn` argument to `r4ss::SS_writestarter()` which has been deprecated in the r4ss package.