### PR TITLE
fix: for multi area models

### DIFF
--- a/R/extendOM.R
+++ b/R/extendOM.R
@@ -424,7 +424,12 @@ update_OM <- function(OM_dir,
           achieved_F <- F_achieved[F_achieved[, "year"] == catch_intended[i, "year"] &
             F_achieved[, "seas"] == catch_intended[i, "seas"] &
             F_achieved[, "fleet"] == catch_intended[i, "fleet"], "F"]
-
+          if(length(achieved_F) > 1) {
+            achieved_F <- achieved_F[achieved_F != 0]
+            if(length(achieved_F) > 1) {
+              stop("achieved_F has a length greater than 1. Contact the SSMSE developers for assistance.")
+            }
+          }
           if (intended_landings == 0) {
             target_F <- 0
           } else if (achieved_landings == 0) {


### PR DESCRIPTION
Fleets only fish in 1 area, so this should work for all multiarea models. Thanks to @skylersagarese-NOAA for identifying this issue and fix!

@skylersagarese-NOAA, could you test and make sure this works for you? If it does, we can merge it into main.

Addresses #175 