### PR TITLE
Fix issue with incorrect param devs default value

### DIFF
--- a/R/single_extend_OM.R
+++ b/R/single_extend_OM.R
@@ -42,8 +42,8 @@ add_OM_devs <- function(ctl, dat, parlist, timeseries, future_om_dat) {
     }
 
     # Set up dummy time varying parameter lines for the control file and parameter file which will be added in for new data
-    tv_dummy <- data.frame(LO = c(0, 0), HI = c(10, 1), INIT = c(.5, .1), PRIOR = c(.5, .1), PR_SD = c(1, 1), PR_type = c(0, 0), PHASE = c(-1, -1))
-    tv_par_dummy <- data.frame(INIT = c(.5, .1), ESTIM = c(.5, .1))
+    tv_dummy <- data.frame(LO = c(0, 0), HI = c(10, 1), INIT = c(1, .1), PRIOR = c(1, .1), PR_SD = c(1, 1), PR_type = c(0, 0), PHASE = c(-1, -1))
+    tv_par_dummy <- data.frame(INIT = c(1, .1), ESTIM = c(1, .1))
     old_par_devs <- parlist[["parm_devs"]]
     new_par_devs <- list()
 

--- a/R/single_extend_OM.R
+++ b/R/single_extend_OM.R
@@ -42,6 +42,8 @@ add_OM_devs <- function(ctl, dat, parlist, timeseries, future_om_dat) {
     }
 
     # Set up dummy time varying parameter lines for the control file and parameter file which will be added in for new data
+    # Note that the first value corresponds with dev_se, the second with rho (autocorrelation). rho needs to be specified but
+    # is not used unless a random walk is specified in SS3.
     tv_dummy <- data.frame(LO = c(0, 0), HI = c(10, 1), INIT = c(1, .1), PRIOR = c(1, .1), PR_SD = c(1, 1), PR_type = c(0, 0), PHASE = c(-1, -1))
     tv_par_dummy <- data.frame(INIT = c(1, .1), ESTIM = c(1, .1))
     old_par_devs <- parlist[["parm_devs"]]


### PR DESCRIPTION
Thanks @charliehinchliffe for pointing out this issue and coming up with the fix! Fixes #186 

- Change the default value for param devs to be 1 instead of 0.5.
- Made a note about the default value of rho, which is not used unless implementing a random walk directly in SS3 (we don't do this in SSMSE, so it remains unused).