### PR TITLE
SSMSE fixes: warnings in r cmd check, documentation

### DIFF
--- a/R/MS_functions.R
+++ b/R/MS_functions.R
@@ -249,19 +249,19 @@ get_EM_catch_df <- function(EM_dir, dat) {
     dplyr::summarise(catch = sum(.data[["catch"]])) %>%
     merge(se, all.x = TRUE, all.y = FALSE) %>%
     dplyr::ungroup() %>%
-    dplyr::select(.data[["year"]], .data[["seas"]], .data[["fleet"]], .data[["catch"]], .data[["catch_se"]])
+    dplyr::select(dplyr::all_of(c("year", "seas", "fleet", "catch","catch_se")))
   catch_bio_df <- catch_bio_df %>%
     dplyr::group_by(.data[["year"]], .data[["seas"]], .data[["fleet"]]) %>%
     dplyr::summarise(catch = sum(.data[["catch"]])) %>%
     merge(se, all.x = TRUE, all.y = FALSE) %>%
     dplyr::ungroup() %>%
-    dplyr::select(.data[["year"]], .data[["seas"]], .data[["fleet"]], .data[["catch"]], .data[["catch_se"]])
+    dplyr::select(dplyr::all_of(c("year", "seas", "fleet", "catch", "catch_se")))
   catch_F_df <- catch_F_df %>%
     dplyr::group_by(.data[["year"]], .data[["seas"]], .data[["fleet"]]) %>%
     dplyr::summarise(catch = sum(.data[["catch"]])) %>%
     merge(se, all.x = TRUE, all.y = FALSE) %>%
     dplyr::ungroup() %>%
-    dplyr::select(.data[["year"]], .data[["seas"]], .data[["fleet"]], .data[["catch"]], .data[["catch_se"]])
+    dplyr::select(dplyr::all_of(c("year","seas","fleet","catch","catch_se")))
 
   catch_df <- as.data.frame(catch_df)
   catch_bio_df <- as.data.frame(catch_bio_df)

--- a/R/calc_F.R
+++ b/R/calc_F.R
@@ -183,7 +183,7 @@ get_retained_catch <- function(timeseries, units_of_catch) {
   retain_catch_df <- retain_catch_df %>%
     dplyr::group_by(.data[["Yr"]], .data[["Era"]], .data[["Seas"]], .data[["Units"]], .data[["Fleet"]]) %>%
     dplyr::summarise(retained_catch = sum(.data[["retained_catch"]])) %>%
-    dplyr::select(.data[["Yr"]], .data[["Era"]], .data[["Seas"]], .data[["Units"]], .data[["Fleet"]], .data[["retained_catch"]])
+    dplyr::select(dplyr::all_of(c("Yr","Era","Seas","Units","Fleet","retained_catch")))
   retain_catch_df <- as.data.frame(retain_catch_df) # want as df and not tibble
   # units are not as concise as they could be, but leave for now.
   retain_catch_df
@@ -242,10 +242,8 @@ get_dead_catch <- function(timeseries, units_of_catch) {
   dead_catch_df <- dead_catch_df %>%
     dplyr::group_by(.data[["Yr"]], .data[["Era"]], .data[["Seas"]], .data[["Units"]], .data[["Fleet"]]) %>%
     dplyr::summarise(retained_catch = sum(.data[["retained_catch"]])) %>%
-    dplyr::select(
-      .data[["Yr"]], .data[["Era"]], .data[["Seas"]], .data[["Units"]], .data[["Fleet"]],
-      .data[["retained_catch"]]
-    )
+    dplyr::select(dplyr::all_of(c("Yr", "Era", "Seas", "Units", "Fleet",
+     "retained_catch")))
   dead_catch_df <- as.data.frame(dead_catch_df)
   # units are not as concise as they could be, but leave for now.
 }

--- a/R/extendOM.R
+++ b/R/extendOM.R
@@ -508,7 +508,7 @@ update_OM <- function(OM_dir,
           qmethod = "double"
         )
       } else {
-        utils::write.table(
+        suppressWarnings(utils::write.table(
           x = search_log,
           file = file.path(OM_dir, "OM_catch_search_log.csv"),
           append = TRUE,
@@ -517,7 +517,7 @@ update_OM <- function(OM_dir,
           sep = ",",
           dec = ".",
           qmethod = "double"
-        )
+        ))
       }
     }
   }

--- a/R/extendOM.R
+++ b/R/extendOM.R
@@ -495,30 +495,16 @@ update_OM <- function(OM_dir,
         verbose = FALSE
       )
 
-
-      if (file.exists(file.path(OM_dir, "OM_catch_search_log.csv"))) {
-        utils::write.table(
-          x = search_log,
-          file = file.path(OM_dir, "OM_catch_search_log.csv"),
-          append = TRUE,
-          row.names = FALSE,
-          col.names = FALSE,
-          sep = ",",
-          dec = ".",
-          qmethod = "double"
+      utils::write.table(
+        x = search_log,
+        file = file.path(OM_dir, "OM_catch_search_log.csv"),
+        append = file.exists(file.path(OM_dir, "OM_catch_search_log.csv")),
+        row.names = FALSE,
+        col.names = !file.exists(file.path(OM_dir, "OM_catch_search_log.csv")),
+        sep = ",",
+        dec = ".",
+        qmethod = "double"
         )
-      } else {
-        suppressWarnings(utils::write.table(
-          x = search_log,
-          file = file.path(OM_dir, "OM_catch_search_log.csv"),
-          append = TRUE,
-          row.names = FALSE,
-          col.names = TRUE,
-          sep = ",",
-          dec = ".",
-          qmethod = "double"
-        ))
-      }
     }
   }
 

--- a/R/initOM_create_devs_list.R
+++ b/R/initOM_create_devs_list.R
@@ -244,7 +244,6 @@ sample_vals <- function(mean,
     # need to think more about if this is correct or  not. this isn't exactly
     # an ar 1 process as described....because the variance isn't constant.
     samps <- vector(mode = "numeric", length = ndevs)
-    nonstat_warning <- TRUE
     for (d in seq_len(ndevs)) {
       if (d == 1) {
         past_samp <- 0 # I think
@@ -256,11 +255,8 @@ sample_vals <- function(mean,
           stats::rnorm(1, mean = 0, sd = sd[d] / sqrt(1 / (1 - ar_1_phi[d]^2)))
       } else {
         samps[d] <- mean[d] + ar_1_phi[d] * past_samp + stats::rnorm(1, mean = 0, sd = sd[d])
-        nonstat_warning <- TRUE
+        warning("An AR1 process with phi >= 1 was called, therefore will be nonstationary.")
       }
-    }
-    if (nonstat_warning) {
-      warning("An AR1 process with phi >= 1 was called, therefore will be nonstationary.")
     }
   }
   samps

--- a/R/initOM_create_devs_list.R
+++ b/R/initOM_create_devs_list.R
@@ -409,8 +409,8 @@ add_dev_changes <- function(fut_list, scen, iter, parlist, dat, vals_df, nyrs, c
       custom_vals <- fut_list[["input"]][fut_list[["input"]][["scen"]] %in% c("all", scen) &
         fut_list[["input"]][["par"]] == i &
         fut_list[["input"]][["iter"]] == iter, ]
-      custom_vals <- dplyr::select(custom_vals, .data[["yr"]], .data[["value"]]) %>%
-        dplyr::rename(yrs = .data[["yr"]])
+      custom_vals <- dplyr::select(custom_vals, dplyr::all_of(c("yr","value"))) %>%
+        dplyr::rename(yrs = "yr")
       vals_df <- dplyr::left_join(vals_df, custom_vals, by = "yrs") %>%
         tidyr::replace_na(replace = list(value = tmp_base))
       vals_df[[i]] <- vals_df[["value"]] # move to the correct column

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,22 +19,16 @@ knitr::opts_chunk$set(
 
 # SSMSE build status
 
-[![call-r-cmd-check](https://github.com/nmfs-fish-tools/SSMSE/actions/workflows/call-r-cmd-check.yml/badge.svg)](https://github.com/nmfs-fish-tools/SSMSE/actions/workflows/call-r-cmd-check.yml)
-[![codecov](https://codecov.io/gh/nmfs-fish-tools/SSMSE/branch/master/graph/badge.svg)](https://codecov.io/gh/nmfs-fish-tools/SSMSE)
-[![DOI](https://joss.theoj.org/papers/10.21105/joss.04937/status.svg)](https://doi.org/10.21105/joss.04937)
+[![badge for the github action call-r-cmd-check](https://github.com/nmfs-fish-tools/SSMSE/actions/workflows/call-r-cmd-check.yml/badge.svg)](https://github.com/nmfs-fish-tools/SSMSE/actions/workflows/call-r-cmd-check.yml)
+[![codecoverage badge](https://codecov.io/gh/nmfs-fish-tools/SSMSE/branch/master/graph/badge.svg)](https://codecov.io/gh/nmfs-fish-tools/SSMSE)
+[![DOI badge](https://joss.theoj.org/papers/10.21105/joss.04937/status.svg)](https://doi.org/10.21105/joss.04937)
+[![Lifecycle badge indicating this repository is stable](https://img.shields.io/badge/lifecycle-stable-green.svg)](https://lifecycle.r-lib.org/articles/stages.html) 
+
+# Current support level for SSMSE
+
+SSMSE is not currently being actively developed. SSMSE is being maintained for bugs fixes only - bug fixes will be addressed, but suggestions for new features and enhancements will not. Changes in staffing in the future could support more active development.
 
 **************
-
-<https://nmfs-fish-tools.github.io/SSMSE/>
-  
-  
-**************
-  
-**This is a repository for the Stock Assessment Tool: SSMSE**
-  
-- Supported by the NOAA Fisheries Integrated Toolbox
-
-
 **Disclaimer**
   
 "The United States Department of Commerce (DOC) GitHub project code is provided on an 'as is' basis and the user assumes responsibility for its use. DOC has relinquished control of the information and no longer has responsibility to protect the integrity, confidentiality, or availability of the information. Any claims against the Department of Commerce stemming from the use of its GitHub project will be governed by all applicable Federal law. Any reference to specific commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply their endorsement, recommendation or favoring by the Department of Commerce. The Department of Commerce seal and logo, or the seal and logo of a DOC bureau, shall not be used in any manner to imply endorsement of any commercial product or activity by DOC or the United States Government."

--- a/tests/testthat/test-future_om.R
+++ b/tests/testthat/test-future_om.R
@@ -197,22 +197,22 @@ test_that("incorrect inputs are caught", {
   )
   future_om_list_mod <- future_om_list
   future_om_list_mod[[1]][["input"]] <- NULL
-  expect_error(
+  suppressWarnings(expect_error(
     check_future_om_list_str(future_om_list = future_om_list_mod),
     "Names of list elements not correct"
-  )
+  ))
   future_om_list_mod <- future_om_list
   future_om_list_mod[[1]][["input"]] <- future_om_list_mod[[1]][["input"]][, -1]
-  expect_error(check_future_om_list_str(future_om_list = future_om_list_mod),
+  suppressWarnings(expect_error(check_future_om_list_str(future_om_list = future_om_list_mod),
     "Because pattern future_om_list[[",
     fixed = TRUE
-  )
+  ))
   future_om_list_mod <- future_om_list
-  future_om_list_mod[[2]]["scen"] <- c("dontreplicate", "scen2")
-  expect_error(check_future_om_list_str(future_om_list = future_om_list_mod),
+  future_om_list_mod[[2]][["scen"]] <- c("dontreplicate", "scen2")
+  suppressWarnings(expect_error(check_future_om_list_str(future_om_list = future_om_list_mod),
     "'arg' should be one of",
     fixed = TRUE
-  )
+  ))
 })
 
 future_om_list <- check_future_om_list_str(future_om_list)
@@ -520,12 +520,18 @@ test_that("creating the devs df works with cv", {
     future_om_list = tmp_future_om_list,
     scen_list = scen_list
   )
-  devs_list <- convert_future_om_list_to_devs_df(
+  # warnings are suppressed because the following warning is expected for many
+  # params:
+  # "Parameter [parameter name] has negative or 0 values and cv is used.The cv is 
+  # still used by calculating sd as abs(cv*mean), which may or may not be 
+  # reasonable for this variable."
+  # Other warnings are not expected.
+  suppressWarnings(devs_list <- convert_future_om_list_to_devs_df(
     future_om_list = tmp_future_om_list,
     scen_name = "scen2",
     niter = 1,
     om_mod_path = om_path, nyrs = 12
-  )
+  ))
   devs_df <- devs_list[["dev_vals"]]
   # modify the following expectations
   expect_true(nrow(devs_df) == 12)

--- a/tests/testthat/test-interim.R
+++ b/tests/testthat/test-interim.R
@@ -13,7 +13,8 @@ test_that("run_SSMSE runs with interim assessment workflow", {
   assess_freq <- 10
   datfile <- system.file("extdata", "models", "cod", "ss3.dat", package = "SSMSE")
   # use sample_struct to get the structure, then modify
-  sample_struct <- create_sample_struct(dat = datfile, nyrs = nyrs)
+  # use suppress warnings to avoid seeing "Pattern not found" warning in test that output
+  suppressWarnings(sample_struct <- create_sample_struct(dat = datfile, nyrs = nyrs))
   sample_struct[["CPUE"]] <- data.frame(Yr = 101:110, Seas = 7, FltSvy = 2, SE = 0.2)
   sample_struct[["agecomp"]] <- NULL
   sample_struct[["lencomp"]] <- NULL
@@ -28,6 +29,7 @@ test_that("run_SSMSE runs with interim assessment workflow", {
     Ref_years = c(0, 0),
     control = FALSE
   )
+
   result <- run_SSMSE(
     scen_name_vec = "base", # name of the scenario
     out_dir_scen_vec = temp_path, # directory in which to run the scenario
@@ -42,6 +44,7 @@ test_that("run_SSMSE runs with interim assessment workflow", {
     interim_struct_list = list(interim_struct_list),
     seed = 12345
   ) # Set a fixed integer seed that allows replication
+
   expect_true(result[["base"]][["errored_iterations"]] == "No errored iterations")
   expect_true(file.exists(file.path(
     temp_path, "base", "1", "cod_OM",

--- a/tests/testthat/test-runSSMSE.R
+++ b/tests/testthat/test-runSSMSE.R
@@ -30,11 +30,11 @@ test_that("run_SSMSE runs with an EM, and works with summary funs", {
   nyrs <- 7
   datfile <- system.file("extdata", "models", "cod", "ss3.dat", package = "SSMSE")
   # use sample_struct to determine its structure
-  sample_struct <- create_sample_struct(
+  sample_struct <- suppressWarnings(create_sample_struct(
     dat = datfile, nyrs = nyrs,
     rm_NAs = TRUE
-  ) # note warning
-  result <- run_SSMSE(
+  )) # note warning
+  result <- suppressWarnings(run_SSMSE(
     scen_name_vec = "H-ctl", # name of the scenario
     out_dir_scen_vec = temp_path, # directory in which to run the scenario
     iter_vec = 1, # run with 5 iterations each
@@ -48,7 +48,7 @@ test_that("run_SSMSE runs with an EM, and works with summary funs", {
     nyrs_assess_vec = 3, # Years between assessments
     sample_struct_list = list(sample_struct), # How to sample data for running the EM.
     seed = 12345
-  ) # Set a fixed integer seed that allows replication
+  )) # Set a fixed integer seed that allows replication
   expect_equivalent(result[["H-ctl"]][["errored_iterations"]], "No errored iterations")
   expect_true(file.exists(file.path(temp_path, "H-ctl", "1", "cod_OM", "data.ss_new")))
   expect_true(file.exists(file.path(temp_path, "H-ctl", "1", "cod_EM_106", "data.ss_new")))
@@ -85,11 +85,11 @@ test_that("run_SSMSE runs multiple iterations/scenarios and works with summary f
   nyrs <- 6
   datfile <- system.file("extdata", "models", "cod", "ss3.dat", package = "SSMSE")
   # use sample_struct to determine its structure
-  sample_struct <- create_sample_struct(dat = datfile, nyrs = nyrs) # note warning
+  sample_struct <- suppressWarnings(create_sample_struct(dat = datfile, nyrs = nyrs)) # note warning
   sample_struct[["lencomp"]] <- NULL
   sample_struct[["meanbodywt"]] <- NULL
   sample_struct[["MeanSize_at_Age_obs"]] <- NULL
-  result <- run_SSMSE(
+  result <- suppressWarnings(run_SSMSE(
     scen_name_vec = c("H-ctl", "H-scen-2"), # name of the scenario
     out_dir_scen_vec = new_temp_path, # directory in which to run the scenario
     iter_vec = c(2, 2), # run with 2 iterations each
@@ -104,7 +104,7 @@ test_that("run_SSMSE runs multiple iterations/scenarios and works with summary f
     run_parallel = FALSE,
     sample_struct_list = list(sample_struct, sample_struct), # How to sample data for running the EM.
     seed = 12345
-  ) # Set a fixed integer seed that allows replication
+  )) # Set a fixed integer seed that allows replication
   expect_equivalent(result[["H-ctl"]][["errored_iterations"]], "No errored iterations")
   expect_true(file.exists(
     file.path(new_temp_path, "H-ctl", "1", "cod_OM", "data.ss_new")
@@ -214,7 +214,7 @@ test_that("cod works when treated as a custom model and run_EM_last_yr = TRUE wo
   dir.create(new_temp_path)
   catch_add_yrs <- 101:106
   add_yrs <- c(102, 105)
-  result <- run_SSMSE_iter(
+  result <- suppressWarnings(run_SSMSE_iter(
     OM_name = NULL,
     OM_in_dir = OM_path_cod,
     MS = "EM",
@@ -239,7 +239,7 @@ test_that("cod works when treated as a custom model and run_EM_last_yr = TRUE wo
         Lbin_lo = -1, Lbin_hi = -1
       )
     )
-  )
+  ))
   expect_true(file.exists(file.path(new_temp_path, "1", "cod_OM", "data.ss_new")))
   expect_true(file.exists(file.path(new_temp_path, "1", "cod_EM_106", "data.ss_new")))
   expect_true(result)

--- a/tests/testthat/test-sample_struct.R
+++ b/tests/testthat/test-sample_struct.R
@@ -232,7 +232,7 @@ test_that("sample_str works with other data types", {
   # dat_gen_size_comp <- r4ss::SS_readdat(
   #   system.file("extdata","test_dat_gen_size_comp.ss", package = "SSMSE"))
   # TODO: make type of the rows/columns standardized?
-  struct <- create_sample_struct(dat_all_types, nyrs = 5)
+  struct <- suppressWarnings(create_sample_struct(dat_all_types, nyrs = 5))
   expect_equivalent(struct[["meanbodywt"]], data.frame(
     Yr = c(2003, 2005),
     Seas = 7,

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -437,10 +437,10 @@ test_that("copy_model_files works", {
   expect_equivalent(success, c(TRUE, TRUE))
 
   # expect_error b/c model files still exist
-  expect_error(copy_model_files(OM_in_dir = cod_in_dir, OM_out_dir = OM_out_dir),
+  suppressWarnings(expect_error(copy_model_files(OM_in_dir = cod_in_dir, OM_out_dir = OM_out_dir),
     "Problem copying SS OM .ss_new files",
     fixed = TRUE
-  )
+  ))
   unlink(OM_out_dir, recursive = TRUE)
   dir.create(OM_out_dir)
   success <- copy_model_files(
@@ -458,14 +458,14 @@ test_that("copy_model_files works", {
   expect_equivalent(success, c(TRUE, TRUE))
   unlink(OM_out_dir, recursive = TRUE)
   dir.create(OM_out_dir)
-  expect_error(
+  suppressWarnings(expect_error(
     copy_model_files(
       OM_in_dir = cod_in_dir, OM_out_dir = OM_out_dir,
       EM_in_dir = cod_in_dir, EM_out_dir = EM_out_dir
     ),
     "Problem copying SS EM files",
     fixed = TRUE
-  )
+  ))
 })
 
 test_that("clean init_mod_files_works", {


### PR DESCRIPTION
Addresses #192 and #194.

The main goal was to get rid of errors in R cmd check that could obscure problematic errors that pop up in the future.

In addition, a note was added on the readme about the SSMSE support level and to denote that the SSMSE UI is stable.