### PR TITLE
fix fragile test for ss3sim

### DIFF
--- a/tests/testthat/test-runSSMSE.R
+++ b/tests/testthat/test-runSSMSE.R
@@ -190,13 +190,15 @@ test_that("run_SSMSE runs multiple iterations/scenarios and works with summary f
   # the following 2 checks should be correct because there are no convergance
   # flags.
   expect_true(all(ssb_check$SSB_ratio > .5) & all(ssb_check$SSB_ratio < 2))
-  # change one of the summary values so that the SSB_ratio > 2
-  summary$ts[4, "SpawnBio"] <- (summary$ts[4, "SpawnBio"])^2 # make really large
+  # change the years summary values so that the SSB_ratio > 2
+  index <- which(summary$ts[,"year"] == 104)[1]
+  summary$ts[index, "SpawnBio"] <- (summary$ts[index, "SpawnBio"])^2 # make really large
   expect_warning(
     ssb_check_warn <- check_convergence(summary, min_yr = 101, max_yr = 106),
     "Some large"
   )
-  expect_true(ssb_check_warn[1, "SSB_ratio"] > 2)
+  row_warn <- which(ssb_check_warn[,"year"]==104)[1]
+  expect_true(ssb_check_warn[row_warn, "SSB_ratio"] > 2)
   # mock params on a bound
   summary$scalar[1, "params_on_bound"] <- "L_at_Amax_Fem_GP_1"
   expect_warning(


### PR DESCRIPTION
One test "broke" due to [changes in ss3sim](https://github.com/ss3sim/ss3sim/pull/424), but it turns out the test was just too fragile.

Changes were made to the SSMSE tests to address this.

